### PR TITLE
Fix regex to be more compatible for non-alphabet languages

### DIFF
--- a/bin/toctoc.js
+++ b/bin/toctoc.js
@@ -15,7 +15,7 @@ function slugify(str) {
     // remove html entities
     .replace(/&\w+;/g, "")
     // generate a github compatible anchor slug
-    .replace(/[^\w]+/g, "-")
+    .replace(/[ $&+,:;=?@#|'<>.^*()%!-]+/g, "-")
     // remove trailing escaped characters
     .replace(/^-/, "")
     .replace(/-$/, "");


### PR DESCRIPTION
Hi. Thank you for this amazing library.

While I was using it for my university project, I realized that it doesn't work for Korean. After digging in, I realized that regex `[^\w]+` also selects non-alphabet language, Korean, and change it to dash making it not recognizable by github anchor slug.

I've changed the regex to manually select specific special characters. However, I couldn't find exact documentation which special character should be changed to dash.

I've confirmed that it works for my project, so creating a PR.

------

Some Photos to show what was happening:

![image](https://user-images.githubusercontent.com/42944002/116788917-321f2000-aae7-11eb-8487-cd95bf4898b6.png)

As you can see, the Korean character is not being recognized .

![image](https://user-images.githubusercontent.com/42944002/116788935-4d8a2b00-aae7-11eb-8d58-0c1b6f9aecbf.png)

With the new change, it properly updates the url.

Thanks!